### PR TITLE
bug: Remove Minimum App Version Checks for Campaigns and Notifications

### DIFF
--- a/lib/dsc/goals.ex
+++ b/lib/dsc/goals.ex
@@ -31,8 +31,6 @@ defmodule DriversSeatCoop.Goals do
   This is in the minimum version in which the goals feature
   is available
   """
-  def app_version_min, do: "3.0.6"
-
   def get_goals(user_id, frequency) do
     query_goals()
     |> query_goals_filter_user(user_id)

--- a/lib/dsc/marketing/campaigns/mileage_tracking_intro_survey.ex
+++ b/lib/dsc/marketing/campaigns/mileage_tracking_intro_survey.ex
@@ -22,7 +22,6 @@ defmodule DriversSeatCoop.Marketing.Campaigns.MileageTrackingIntroSurvey do
     |> Campaign.is_qualified(fn %CampaignState{} = state ->
       is_qualified?(state.user, state.device, state.participant)
     end)
-    |> Campaign.exclude_app_version("< 3.0.8")
     |> Survey.with_section(
       SurveySection.new(:welcome)
       |> SurveySection.with_title("Track your Total Work Miles!")

--- a/lib/dsc/marketing/campaigns/onboarding_checklist.ex
+++ b/lib/dsc/marketing/campaigns/onboarding_checklist.ex
@@ -12,7 +12,6 @@ defmodule DriversSeatCoop.Marketing.Campaigns.OnboardingChecklist do
     Checklist.new(:onboarding_checklist)
     |> Campaign.with_category(:to_dos)
     |> Campaign.is_qualified(fn %CampaignState{} = state -> is_qualified(state) end)
-    |> Campaign.include_app_version(">= 3.1.0")
     |> Checklist.with_title("Finish Setting Up Driver's Seat")
     |> Checklist.show_progress()
     |> Checklist.with_item(fn %CampaignState{} = state -> get_items(state) end)

--- a/lib/dsc/notifications/oban/cta_goals_check_progress.ex
+++ b/lib/dsc/notifications/oban/cta_goals_check_progress.ex
@@ -17,20 +17,14 @@ defmodule DriversSeatCoop.Notifications.Oban.CTAGoalsCheckProgress do
 
   alias DriversSeatCoop.Accounts
   alias DriversSeatCoop.Accounts.User
-  alias DriversSeatCoop.Devices
-  alias DriversSeatCoop.Goals
   alias DriversSeatCoop.OneSignal
   alias DriversSeatCoop.Repo
 
   def schedule_jobs do
-    current_version_user_ids_qry =
-      Devices.get_user_ids_on_version_or_greater_query(Goals.app_version_min())
-
     included_users =
       Accounts.get_users_query()
       |> Accounts.filter_include_users_with_earnings_query()
       |> Accounts.filter_include_users_with_earnings_goals_query()
-      |> where([u], u.id in subquery(current_version_user_ids_qry))
       |> select([u], u.id)
       |> Repo.all()
 

--- a/lib/dsc/notifications/oban/cta_goals_link_accounts.ex
+++ b/lib/dsc/notifications/oban/cta_goals_link_accounts.ex
@@ -17,8 +17,6 @@ defmodule DriversSeatCoop.Notifications.Oban.CTAGoalsLinkAccounts do
 
   alias DriversSeatCoop.Accounts
   alias DriversSeatCoop.Accounts.User
-  alias DriversSeatCoop.Devices
-  alias DriversSeatCoop.Goals
   alias DriversSeatCoop.Marketing
   alias DriversSeatCoop.OneSignal
   alias DriversSeatCoop.Repo
@@ -30,9 +28,6 @@ defmodule DriversSeatCoop.Notifications.Oban.CTAGoalsLinkAccounts do
       DateTime.utc_now()
       |> DateTime.add(@schedule_future_minutes * -1, :minute)
 
-    current_version_user_ids_qry =
-      Devices.get_user_ids_on_version_or_greater_query(Goals.app_version_min())
-
     user_ids_interested_qry =
       Marketing.query_campaign_participation()
       |> Marketing.query_filter_campaign("goals_survey")
@@ -42,7 +37,6 @@ defmodule DriversSeatCoop.Notifications.Oban.CTAGoalsLinkAccounts do
     included_users =
       Accounts.get_users_query()
       |> Accounts.filter_include_users_without_earnings_query()
-      |> where([u], u.id in subquery(current_version_user_ids_qry))
       |> where([u], u.id in subquery(user_ids_interested_qry))
       |> where([u], u.inserted_at <= ^qulified_after)
       |> select([u], u.id)

--- a/lib/dsc/notifications/oban/cta_goals_set_goals.ex
+++ b/lib/dsc/notifications/oban/cta_goals_set_goals.ex
@@ -18,16 +18,11 @@ defmodule DriversSeatCoop.Notifications.Oban.CTAGoalsSetGoals do
 
   alias DriversSeatCoop.Accounts
   alias DriversSeatCoop.Accounts.User
-  alias DriversSeatCoop.Devices
-  alias DriversSeatCoop.Goals
   alias DriversSeatCoop.Marketing
   alias DriversSeatCoop.OneSignal
   alias DriversSeatCoop.Repo
 
   def schedule_jobs do
-    current_version_user_ids_qry =
-      Devices.get_user_ids_on_version_or_greater_query(Goals.app_version_min())
-
     user_ids_interested_qry =
       Marketing.query_campaign_participation()
       |> Marketing.query_filter_campaign("goals_survey")
@@ -37,7 +32,6 @@ defmodule DriversSeatCoop.Notifications.Oban.CTAGoalsSetGoals do
 
     included_users =
       Accounts.get_users_query()
-      |> where([u], u.id in subquery(current_version_user_ids_qry))
       |> where([u], u.id in subquery(user_ids_interested_qry))
       |> Accounts.filter_include_users_with_earnings_query()
       |> Accounts.filter_include_users_without_earnings_goals_query()


### PR DESCRIPTION
* In the original app, the concept of a campaign evolved over time.  To allow for this, there were filters against calling-app version for certain campaigns.
* Originally, all campaigns were presented as interrupt campaigns.  When this changed, app version filtering was used to prevent campaigns from being intrusive when they had already been completed.
* When preparing the list of campaigns to present to the user, switch the order of evaluation.  First version checks (they are easy), then is_qualified (which may be more intensive).