### PR TITLE
performance: Improve performance by excluding geometry fields from region queries

### DIFF
--- a/lib/dsc/regions/county.ex
+++ b/lib/dsc/regions/county.ex
@@ -3,6 +3,9 @@ defmodule DriversSeatCoop.Regions.County do
   import Ecto.Changeset
 
   @sync_fields ~w(id name region_id_state geometry)a
+  @all_fields_except_geometry @sync_fields -- [:geometry]
+
+  def get_non_geometry_fields, do: @all_fields_except_geometry
 
   schema "region_county" do
     field :name, :string

--- a/lib/dsc/regions/metro_area.ex
+++ b/lib/dsc/regions/metro_area.ex
@@ -27,6 +27,10 @@ defmodule DriversSeatCoop.Regions.MetroArea do
     hourly_pay_stat_coverage_count_tasks_services
   )a
 
+  @all_fields_except_geometry (@sync_fields ++ @stats_fields) -- [:geometry]
+
+  def get_non_geometry_fields, do: @all_fields_except_geometry
+
   schema "region_metro_area" do
     field :name, :string
     field :full_name, :string

--- a/lib/dsc/regions/postal_code.ex
+++ b/lib/dsc/regions/postal_code.ex
@@ -5,6 +5,10 @@ defmodule DriversSeatCoop.Regions.PostalCode do
   @sync_required_fields ~w(id postal_code geometry region_id_county region_id_state)a
   @sync_optional_fields ~w(region_id_metro_area)a
 
+  @all_fields_except_geometry (@sync_required_fields ++ @sync_optional_fields) -- [:geometry]
+
+  def get_non_geometry_fields, do: @all_fields_except_geometry
+
   schema "region_postal_code" do
     field :postal_code, :string
     field :geometry, Geo.PostGIS.Geometry

--- a/lib/dsc/regions/state.ex
+++ b/lib/dsc/regions/state.ex
@@ -3,6 +3,9 @@ defmodule DriversSeatCoop.Regions.State do
   import Ecto.Changeset
 
   @sync_fields ~w(id name abbrv geometry)a
+  @all_fields_except_geometry @sync_fields -- [:geometry]
+
+  def get_non_geometry_fields, do: @all_fields_except_geometry
 
   schema "region_state" do
     field :name, :string

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -583,6 +583,7 @@ defmodule DriversSeatCoop.Factory do
 
     MetroArea.stats_changeset(metro, attrs)
     |> Repo.insert_or_update!()
+    |> Map.put(:geometry, nil)
   end
 
   def create_state(id, attrs \\ %{}) do
@@ -601,6 +602,7 @@ defmodule DriversSeatCoop.Factory do
 
     State.sync_changeset(state, attrs)
     |> Repo.insert_or_update!()
+    |> Map.put(:geometry, nil)
   end
 
   def create_county(id, state_id, attrs \\ %{}) do
@@ -619,6 +621,7 @@ defmodule DriversSeatCoop.Factory do
 
     County.sync_changeset(county, attrs)
     |> Repo.insert_or_update!()
+    |> Map.put(:geometry, nil)
   end
 
   def create_postal_code(id, postal_code, county_id, state_id, metro_area_id \\ nil) do
@@ -637,5 +640,6 @@ defmodule DriversSeatCoop.Factory do
 
     PostalCode.sync_changeset(postal_code, attrs)
     |> Repo.insert_or_update!()
+    |> Map.put(:geometry, nil)
   end
 end


### PR DESCRIPTION
In all cases, when querying regions (states, counties, postal codes, metro_areas), the geometry field value is not necessary.
* Modify region queries to remove this field while still returning the Structs.