### PR TITLE
bug: Remove OneSignal template references

### DIFF
--- a/lib/dsc/one_signal.ex
+++ b/lib/dsc/one_signal.ex
@@ -1,14 +1,4 @@
 defmodule DriversSeatCoop.OneSignal do
-  defmodule MessageTemplateParams do
-    @enforce_keys [:include_external_user_ids, :template_id]
-    defstruct [
-      :include_external_user_ids,
-      :additional_data,
-      :template_id,
-      :title
-    ]
-  end
-
   defmodule NonTemplateMessageParams do
     @enforce_keys [:include_external_user_ids, :title, :body]
     defstruct [
@@ -24,36 +14,34 @@ defmodule DriversSeatCoop.OneSignal do
   alias DriversSeatCoop.Accounts
   alias DriversSeatCoop.Accounts.User
   alias DriversSeatCoop.Mixpanel
-  alias DriversSeatCoop.OneSignal.MessageTemplateParams
   alias DriversSeatCoop.OneSignal.NonTemplateMessageParams
 
   @url "https://onesignal.com/api/v1/notifications"
 
-  def send_notification_app_update_available(%User{} = user, _version_id) do
-    send_notification(user, :app_update_available, %MessageTemplateParams{
-      template_id: "8d4ef2ae-000c-4d47-b010-a3dbcf0f63c0",
-      include_external_user_ids: [user.id]
-    })
-  end
-
   def send_notification_goals_check_progress(%User{} = user) do
-    send_notification(user, :cta_goals_check_progress, %MessageTemplateParams{
-      template_id: "191a3678-d720-4077-a89f-f5715f866ae1",
-      include_external_user_ids: [user.id]
+    send_notification(user, :cta_goals_check_progress, %NonTemplateMessageParams{
+      include_external_user_ids: [user.id],
+      title: "Track your earnings goals!",
+      body:
+        "Check out the Earnings tab in Driver's Seat to monitor how you are doing against your earnings goal."
     })
   end
 
   def send_notification_goals_link_accounts(%User{} = user) do
-    send_notification(user, :cta_goals_link_accounts, %MessageTemplateParams{
-      template_id: "0f4b8921-41e5-4ceb-8aa2-b63d8c4798e4",
-      include_external_user_ids: [user.id]
+    send_notification(user, :cta_goals_link_accounts, %NonTemplateMessageParams{
+      include_external_user_ids: [user.id],
+      title: "New: Set & track your earnings goals!",
+      body:
+        "We just added a new feature that lets you monitor progress against your earnings goals on Driver's Seat. Connect a gig account to get started!"
     })
   end
 
   def send_notification_goals_set_goals(%User{} = user) do
-    send_notification(user, :cta_goals_set_goals, %MessageTemplateParams{
-      template_id: "aad6192e-a582-4dd6-b5ca-23176f97b3da",
-      include_external_user_ids: [user.id]
+    send_notification(user, :cta_goals_set_goals, %NonTemplateMessageParams{
+      include_external_user_ids: [user.id],
+      title: "New: Set & track your earnings goals!",
+      body:
+        "Check out the Earnings tab in Driver's Seat to set a new earnings goal and monitor your progress as you work."
     })
   end
 
@@ -227,11 +215,12 @@ defmodule DriversSeatCoop.OneSignal do
   end
 
   def send_cta_welcome_to_insights(%User{} = user, count_users_with_jobs) do
-    send_notification(user, :cta_earnings_insights, %MessageTemplateParams{
-      template_id: "1cfe418a-0def-4741-80f0-55bb7fa1b4ad",
+    send_notification(user, :cta_earnings_insights, %NonTemplateMessageParams{
       include_external_user_ids: [user.id],
       title:
         "Join #{Number.Delimit.number_to_delimited(count_users_with_jobs, precision: 0)} others on Driver's Seat",
+      body:
+        "Other gig workers like you are getting insights into their earnings. Click here to learn more.",
       additional_data: %{
         count_users_with_jobs: count_users_with_jobs
       }
@@ -242,11 +231,12 @@ defmodule DriversSeatCoop.OneSignal do
         %User{} = user,
         count_users_with_community_insights
       ) do
-    send_notification(user, :cta_community_insights, %MessageTemplateParams{
-      template_id: "563d4848-e4e6-414d-8421-9ad0adce46f1",
+    send_notification(user, :cta_community_insights, %NonTemplateMessageParams{
       include_external_user_ids: [user.id],
       title:
         "#{Number.Delimit.number_to_delimited(count_users_with_community_insights, precision: 0)} workers share earning tips!",
+      body:
+        "Visit the Insights tab to see what gig workers in nearby areas have been earning, for different apps and times of day.",
       additional_data: %{
         count_users_with_community_insights: count_users_with_community_insights,
         metro_area: "NULL"
@@ -261,29 +251,24 @@ defmodule DriversSeatCoop.OneSignal do
         true = _enough_data,
         has_activity_data
       ) do
-    params = %MessageTemplateParams{
-      template_id: "df87fc4f-69de-4cd9-b8bf-1e8f04659b1e",
+    title =
+      if metro_area.count_workers < 5,
+        do: "Learn from other workers nearby!",
+        else:
+          "Learn from #{Number.Delimit.number_to_delimited(metro_area.count_workers, precision: 0)} workers nearby!"
+
+    send_notification(user, :cta_community_insights, %NonTemplateMessageParams{
       include_external_user_ids: [user.id],
+      title: title,
+      body:
+        "Driver's Seat tracks what other gig workers in your area have been earning recently. Check the Insights tab to see the top gig apps and times with the highest earnings rates.",
       additional_data: %{
         metro_area: metro_area.name,
         count_workers_in_metro: metro_area.count_workers,
         metro_has_enough_data: true,
         user_has_activities: has_activity_data
       }
-    }
-
-    params =
-      if metro_area.count_workers < 5 do
-        params
-      else
-        Map.put(
-          params,
-          :title,
-          "Learn from #{Number.Delimit.number_to_delimited(metro_area.count_workers, precision: 0)} workers nearby!"
-        )
-      end
-
-    send_notification(user, :cta_community_insights, params)
+    })
   end
 
   # Metro DOES NOT have enough data and the user HAS NOT registered their argyle accounts
@@ -293,29 +278,24 @@ defmodule DriversSeatCoop.OneSignal do
         false = _enough_data,
         false = _has_activity_data
       ) do
-    params = %MessageTemplateParams{
-      template_id: "65f81062-3db9-4dd7-8ced-0b9ffb7aec01",
+    title =
+      if metro_area.count_workers < 5,
+        do: "Your community needs you!",
+        else:
+          "#{Number.Delimit.number_to_delimited(metro_area.count_workers, precision: 0)} workers nearby need you!"
+
+    send_notification(user, :cta_community_insights, %NonTemplateMessageParams{
       include_external_user_ids: [user.id],
+      title: title,
+      body:
+        "Gig workers in your area are working together to track how much the gig apps are paying. You can contribute data, and get back insights, by connecting your gig apps.",
       additional_data: %{
         metro_area: metro_area.name,
         count_workers: metro_area.count_workers,
         metro_has_enough_data: false,
         user_has_activities: false
       }
-    }
-
-    params =
-      if metro_area.count_workers < 5 do
-        params
-      else
-        Map.put(
-          params,
-          :title,
-          "#{Number.Delimit.number_to_delimited(metro_area.count_workers, precision: 0)} workers nearby need you!"
-        )
-      end
-
-    send_notification(user, :cta_community_insights, params)
+    })
   end
 
   # Metro does NOT have enough data and the user HAS registered their argyle accounts
@@ -330,9 +310,11 @@ defmodule DriversSeatCoop.OneSignal do
 
   def send_shift_start_reminder(%User{} = user, shift_start_time_local) do
     if User.can_receive_start_shift_notification(user) do
-      send_notification(user, :start_shift_reminder, %MessageTemplateParams{
-        template_id: "234be7ad-e1d3-4996-a001-de0b06fac100",
+      send_notification(user, :start_shift_reminder, %NonTemplateMessageParams{
         include_external_user_ids: [user.id],
+        title: "Start Shift in Driver's Seat",
+        body:
+          "Reminder: It's time to start your shift on Driver's Seat! Push the 'Start Shift' button when you start working so your total work time and mileage are captured.",
         additional_data: %{
           shift_start_time_local: shift_start_time_local
         }
@@ -344,9 +326,11 @@ defmodule DriversSeatCoop.OneSignal do
 
   def send_shift_end_reminder(%User{} = user, shift_end_time_local) do
     if User.can_receive_end_shift_notification(user) do
-      send_notification(user, :end_shift_reminder, %MessageTemplateParams{
-        template_id: "489daa0d-1229-4f27-be02-cfbff8d87884",
+      send_notification(user, :end_shift_reminder, %NonTemplateMessageParams{
         include_external_user_ids: [user.id],
+        title: "Complete your shift in Driver's Seat",
+        body:
+          "Remember to end your shift in Driver's Seat! When you're done working, turn off the shift tracker so your total work time and mileage are accurately captured.",
         additional_data: %{
           shift_end_time_local: shift_end_time_local
         }
@@ -360,39 +344,15 @@ defmodule DriversSeatCoop.OneSignal do
     user = Accounts.get_user!(user_id)
 
     if User.can_receive_notification(user) do
-      send_notification(user, :argyle_activities_available, %MessageTemplateParams{
-        template_id: "916e4ec9-89d5-4367-93ba-53130067afee",
-        include_external_user_ids: [user.id]
+      send_notification(user, :argyle_activities_available, %NonTemplateMessageParams{
+        include_external_user_ids: [user.id],
+        title: "Your Data is Ready",
+        body:
+          "Hi #{user.first_name || "there"},  Your work data is ready to be viewed in Driver's Seat!"
       })
     else
       {:ok, :user_cannot_receive_notification}
     end
-  end
-
-  defp send_notification(%User{} = user, notification_type, %MessageTemplateParams{} = params) do
-    include_external_user_ids =
-      params.include_external_user_ids
-      |> Enum.map(&to_string/1)
-
-    body = %{
-      template_id: params.template_id,
-      include_external_user_ids: include_external_user_ids,
-      channel_for_external_user_ids: "push"
-    }
-
-    # if there is a title, add it
-    title = Map.get(params, :title)
-
-    body =
-      if is_nil(title) do
-        body
-      else
-        Map.put(body, :headings, %{
-          en: title
-        })
-      end
-
-    send(user, notification_type, body, Map.get(params, :additional_data))
   end
 
   defp send_notification(%User{} = user, notification_type, %NonTemplateMessageParams{} = params) do


### PR DESCRIPTION
Remove the use of Onesignal templates and move the template text into the elixir code.
